### PR TITLE
Support PHP 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.3
   - 7.4
   - 8.0
+  - 8.1
 
 before_install: phpenv config-add ./tests/php.ini
 

--- a/src/Time/Duration.php
+++ b/src/Time/Duration.php
@@ -216,7 +216,7 @@ class Duration implements \JsonSerializable
     /**
      * @return int
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): int
     {
         return $this->ns;
     }

--- a/src/Time/Month.php
+++ b/src/Time/Month.php
@@ -90,7 +90,7 @@ class Month implements \JsonSerializable
     /**
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return (string)$this;
     }

--- a/src/Time/Weekday.php
+++ b/src/Time/Weekday.php
@@ -77,7 +77,7 @@ class Weekday implements \JsonSerializable
     /**
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return (string)$this;
     }


### PR DESCRIPTION
PHP Fatal error:  During inheritance of JsonSerializable:
Uncaught ErrorException: Return type of DCarbone\Go\Time\Duration::jsonSerialize()
should either be compatible with JsonSerializable::jsonSerialize(): mixed,
or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice